### PR TITLE
API /me 수정

### DIFF
--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,16 +1,18 @@
 import { editUserInfo, getUserInfo } from '@/db/controllers';
 import { handleError } from '@/db/utils';
 import { revalidatePath } from 'next/cache';
+import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
 // 로그인한 사용자의 정보 가져오기
 export async function GET(req: NextRequest) {
+  const token = cookies().get('access_token')?.value;
   try {
-    const user = await getUserInfo();
+    const data = token ? await getUserInfo(token) : null;
     return NextResponse.json(
       {
         success: true,
-        data: user,
+        data,
         message: '사용자 정보를 성공적으로 가져왔습니다.',
       },
       { status: 200 },

--- a/src/db/controllers/users.controller.ts
+++ b/src/db/controllers/users.controller.ts
@@ -7,17 +7,24 @@ import {
   getAuthenticatedUser,
   getLoginUserId,
   getPaginatedSentences,
+  verifyToken,
 } from '../utils';
 
 /**
  * 로그인한 사용자 정보를 반환
  */
-export const getUserInfo = async (): Promise<User> => {
+export const getUserInfo = async (token: string): Promise<User | null> => {
   try {
     await connectDB();
-    const user = await getAuthenticatedUser();
+    const decoded = verifyToken(token);
+    const userId = decoded?.userId;
+    if (!userId) {
+      return null;
+    }
+    const user = await models.User.findById(userId).lean<User>();
     if (!user) {
-      throw new HttpError('UNAUTHORIZED', 401, '로그인 후 이용해주세요.');
+      console.warn(`DB에 해당 사용자 없음, userID: ${userId}`);
+      return null;
     }
     return user;
   } catch (error) {


### PR DESCRIPTION
- [GET] /me 반환값 변경
   - 기존 단순히 로그인하지 않은 사용자도 에러(401)를 받는 구조
   - 로그인 상태이면 사용자 정보를 제공하고, 아니면 그냥 null을 반환
- cookies() 를 최상위에서 호출하도록 수정
  - DynamicServerError 대응
  -  https://nextjs.org/docs/messages/dynamic-server-error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 로그인된 사용자의 정보를 조회할 때, 쿠키에서 액세스 토큰을 명확하게 가져와 처리하도록 개선되었습니다.
  - 사용자 정보 응답의 JSON 키가 'user'에서 'data'로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->