### PR TITLE
refactor: 기본 프로필 이미지 경로를 상수로 통일

### DIFF
--- a/src/app/(main)/components/Header/HeaderMenu/index.tsx
+++ b/src/app/(main)/components/Header/HeaderMenu/index.tsx
@@ -8,7 +8,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { memo, useState } from 'react';
 
-import blankProfile from '../../../../../../public/images/blank-profile.png';
+import { DEFAULT_PROFILE } from '@/constants';
 import classes from './HeaderMenu.module.scss';
 import { useLogout, useUserQuery } from './hooks';
 
@@ -67,7 +67,7 @@ const HeaderMenu: React.FC = memo(function HeaderMenu() {
           width={40}
           height={40}
           alt={user.name}
-          src={user.profileUrl || blankProfile}
+          src={user.profileUrl || DEFAULT_PROFILE}
         />
       </IconButton>
       <Menu

--- a/src/components/molecules/UserInfo/index.tsx
+++ b/src/components/molecules/UserInfo/index.tsx
@@ -1,6 +1,6 @@
+import { DEFAULT_PROFILE } from '@/constants';
 import type { User } from '@/types';
 import Image from 'next/image';
-import blankProfile from '../../../../public/images/blank-profile.png';
 import classes from './UserInfo.module.scss';
 
 type UserInfoProps = {
@@ -15,7 +15,7 @@ export default function UserInfo({ user, className }: UserInfoProps) {
         width={30}
         height={30}
         alt={user.name || ''}
-        src={user.profileUrl || blankProfile}
+        src={user.profileUrl || DEFAULT_PROFILE}
       />
       <div className="name">{user.name}</div>
     </div>


### PR DESCRIPTION
- 컴포넌트 내 상대경로(import) 방식의 이미지 사용을 제거하고, 절대경로 상수를 사용하는 방식으로 일괄 변경
- constants 경로에 정의된 DEFAULT_PROFILE 상수를 사용하도록 수정
- 컴포넌트의 이동 및 재사용 시 이미지 경로 유지보수를 간소화하기 위한 리팩터링 작업

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 사용자 프로필 이미지의 기본값을 중앙에서 관리되는 상수로 통일하여 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->