### PR TITLE
refactor: MUI 테마 설정 위치 변경

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
-import type { Preview } from '@storybook/react';
 import { ThemeProvider } from '@mui/material';
+import type { Preview } from '@storybook/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
 import '../src/styles/global.scss';
 
-import { MUI_THEME } from '../src/constants';
+import { MUI_THEME } from '../src/lib/mui/theme';
 
 const preview: Preview = {
   parameters: {

--- a/src/app/(main)/components/ClientProviders/index.tsx
+++ b/src/app/(main)/components/ClientProviders/index.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import { MUI_THEME } from '@/lib/mui/theme';
+import { ThemeProvider } from '@mui/material';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'react-hot-toast';
-import { MUI_THEME } from '@/constants';
-import { ThemeProvider } from '@mui/material';
 
 const queryClient = new QueryClient();
 export default function ClientProviders({

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,18 +1,1 @@
-import { colors, createTheme } from '@mui/material';
-
 export const DEFAULT_PROFILE = '/images/blank-profile.png';
-
-export const MUI_THEME = createTheme({
-  palette: {
-    secondary: {
-      main: colors.blueGrey[800],
-    },
-  },
-  components: {
-    MuiButton: {
-      defaultProps: {
-        disableElevation: true,
-      },
-    },
-  },
-});

--- a/src/lib/mui/theme.ts
+++ b/src/lib/mui/theme.ts
@@ -1,0 +1,16 @@
+import { colors, createTheme } from '@mui/material';
+
+export const MUI_THEME = createTheme({
+  palette: {
+    secondary: {
+      main: colors.blueGrey[800],
+    },
+  },
+  components: {
+    MuiButton: {
+      defaultProps: {
+        disableElevation: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## 작업 배경
- MUI와 같은 외부 라이브러리 설정은 `lib` 폴더에서 관리하는 것이 적합

## 변경 내용
- `MUI_THEME`를 정의한 파일을 `lib/mui/theme.ts`로 이동
- `import` 경로를 `@/constants` → `@/lib/mui/theme`로 변경