### PR TITLE
Like 버튼 클릭 시 로그인 여부 확인 및 비로그인 사용자 안내 추가

### DIFF
--- a/src/components/molecules/LikeButton/index.tsx
+++ b/src/components/molecules/LikeButton/index.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import toast from 'react-hot-toast';
 import { FaHeart, FaRegHeart } from 'react-icons/fa6';
 
+import { useUserStore } from '@/store/user';
 import classes from './LikeButton.module.scss';
 import { toggleSentenceLike } from './api';
 
@@ -30,9 +31,17 @@ export default function LikeButton({
   color = 'secondary',
 }: LikeButtonProps) {
   const [isLiked, setIsLiked] = useState(initialLiked);
+  const { isLogin } = useUserStore.getState();
   const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
+
+    // 로그인하지 않은 경우 요청을 보내지 않는다.
+    if (!isLogin) {
+      toast('로그인 후에 이용해주세요.');
+      return;
+    }
+
     try {
       await toggleSentenceLike(id, isLiked);
       setIsLiked(!isLiked);


### PR DESCRIPTION
## 작업 배경
- Like 버튼 클릭 시 로그인하지 않은 사용자를 구분하지 않고 있어서 불필요한 API 요청이 가고 있었습니다.  그렇기 때문에 요청 전 로그인 여부 확인이 필요했습니다. 

## 변경 내용
- 버튼 클릭 시 로그인 여부 상태 확인
- 로그인하지 않은 경우 Toast로 피드백 제공
- 로그인된 경우에만 API 요청 실행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 좋아요 버튼 클릭 시 로그인 상태를 확인하고, 비로그인 상태에서는 로그인 안내 알림을 표시합니다.  
- **버그 수정**
    - 비로그인 사용자가 좋아요 버튼을 클릭해도 동작하지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->