### PR TITLE
access_token으로 로그인 상태 유지 처리

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -3,7 +3,7 @@ import type { User } from '@/types';
 import { fetchAPI } from './fetcher';
 
 export const getUser = async () => {
-  return fetchAPI<User>('/users/me');
+  return fetchAPI<User>('/users/me', { cache: 'no-store' });
 };
 
 export const updateUser = async (data: Record<string, any>) => {

--- a/src/app/(main)/components/UserProvider/index.tsx
+++ b/src/app/(main)/components/UserProvider/index.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
 
 // Zustand 초기화용 컴포넌트
 type UserProviderProps = {
-  user?: User;
+  user: User | null;
 };
 export default function UserProvider({ user }: UserProviderProps) {
   const setUser = useUserStore.use.setUser();

--- a/src/app/(main)/components/UserProvider/index.tsx
+++ b/src/app/(main)/components/UserProvider/index.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useUserStore } from '@/store/user';
+import { User } from '@/types';
+import { useEffect } from 'react';
+
+// Zustand 초기화용 컴포넌트
+type UserProviderProps = {
+  user?: User;
+};
+export default function UserProvider({ user }: UserProviderProps) {
+  const setUser = useUserStore.use.setUser();
+  const setIsLogin = useUserStore.use.setIsLogin();
+
+  useEffect(() => {
+    if (user) {
+      setUser(user);
+      setIsLogin(true);
+    } else {
+      setUser(null);
+      setIsLogin(false);
+    }
+  }, [user]);
+
+  return null;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,15 @@ export default async function MainPage({ searchParams }: MainPageProps) {
 
   const cookieStore = cookies();
   const token = cookieStore.get('access_token');
-  const user = !!token?.value ? await getUser() : null;
+  let user = null;
+  if (token?.value) {
+    try {
+      const { data } = await getUser();
+      user = data;
+    } catch (error) {
+      console.error('사용자 정보 가져오기 실패:', error);
+    }
+  }
 
   const {
     data: { list, totalPages },
@@ -33,7 +41,7 @@ export default async function MainPage({ searchParams }: MainPageProps) {
 
   return (
     <main>
-      <UserProvider user={user?.data} />
+      <UserProvider user={user} />
       <MaxWidthWrapper>
         <div className={classes.buttons}>
           <SortButtons />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,9 +2,12 @@ import { MaxWidthWrapper } from '@/components/atoms';
 import { Pagination } from '@/components/molecules';
 import { SentenceLikeCardList } from '@/components/organisms';
 import { getSortByValue, getSortOrderValue } from '@/utils';
+import { cookies } from 'next/headers';
 
+import { getUser } from '@/api/user';
 import { getSentences } from './(main)/api';
 import { SortButtons } from './(main)/components';
+import UserProvider from './(main)/components/UserProvider';
 import classes from './page.module.scss';
 
 type MainPageProps = {
@@ -15,6 +18,11 @@ export default async function MainPage({ searchParams }: MainPageProps) {
   const _searchParams = new URLSearchParams(searchParams);
   const sortBy = getSortByValue(_searchParams.get('sortBy'));
   const sortOrder = getSortOrderValue(_searchParams.get('sortOrder'));
+
+  const cookieStore = cookies();
+  const token = cookieStore.get('access_token');
+  const user = !!token?.value ? await getUser() : null;
+
   const {
     data: { list, totalPages },
   } = await getSentences({
@@ -25,6 +33,7 @@ export default async function MainPage({ searchParams }: MainPageProps) {
 
   return (
     <main>
+      <UserProvider user={user?.data} />
       <MaxWidthWrapper>
         <div className={classes.buttons}>
           <SortButtons />

--- a/src/db/controllers/users.controller.ts
+++ b/src/db/controllers/users.controller.ts
@@ -1,5 +1,6 @@
 import { PaginationRequest, User } from '@/types';
 import { HttpError } from '@/utils';
+import { TokenExpiredError } from 'jsonwebtoken';
 import connectDB from '../connectDB';
 import firebaseAdmin from '../firebase.config';
 import models from '../models';
@@ -28,6 +29,10 @@ export const getUserInfo = async (token: string): Promise<User | null> => {
     }
     return user;
   } catch (error) {
+    // 만료된 토큰은 에러를 던지지 않고 사용자 정보를 보내지 않는 것으로 처리
+    if (error instanceof TokenExpiredError) {
+      return null;
+    }
     console.error(`사용자 정보 가져오기 실패`, error);
     throw new HttpError();
   }

--- a/src/db/utils/auth.ts
+++ b/src/db/utils/auth.ts
@@ -1,5 +1,5 @@
 import { User } from '@/types/user';
-import jwt, { JwtPayload } from 'jsonwebtoken';
+import jwt, { JwtPayload, TokenExpiredError } from 'jsonwebtoken';
 import { cookies } from 'next/headers';
 import models from '../models';
 
@@ -12,7 +12,7 @@ export const getAuthenticatedUser = async (): Promise<User | null> => {
     const userId = getLoginUserId();
     return userId ? await models.User.findById(userId).lean<User>() : null;
   } catch (error) {
-    console.error('JWT 검증 실패:', error);
+    console.error('사용자 정보 찾기 실패', error);
     return null;
   }
 };
@@ -44,7 +44,10 @@ export const getLoginUserId = (): string | null => {
     const decoded = verifyToken(token);
     return decoded?.userId;
   } catch (error) {
-    console.error('JWT 검증 실패:', error);
+    // 토큰 만료 에러는 무시
+    if (!(error instanceof TokenExpiredError)) {
+      console.error('JWT 검증 실패:', error);
+    }
     return null;
   }
 };

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -10,10 +10,7 @@ export type UserState = {
 };
 
 const useUserStoreBase = create<UserState>((set) => ({
-  isLogin:
-    typeof window === 'undefined'
-      ? false
-      : !!localStorage.getItem('access_token'),
+  isLogin: false,
   user: null,
   setIsLogin: (isLogin: boolean) => set((state) => ({ ...state, isLogin })),
   setUser: (user) => set((state) => ({ ...state, user })),


### PR DESCRIPTION
## 작업 개요
- 로그인 후 새로고침 시 access_token은 유지되지만, 클라이언트 상태에서는 로그인 정보가 사라지는 문제를 해결하기 위한 작업입니다.
- 서버에서 access_token을 기반으로 사용자 정보를 받아와 클라이언트 zustand store에 저장하도록 처리했습니다.

## 주요 변경사항
- 초기 렌더 시 서버에서 `/users/me` 호출 후 UserProvider 컴포넌트에서 store 상태 세팅
- /users/me API 호출 시 `cache: 'no-store'` 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 사용자 인증 상태를 초기화하고 관리하는 UserProvider 컴포넌트가 추가되었습니다.

- **Bug Fixes**
  - 만료된 토큰으로 사용자 정보를 요청할 때 더 이상 오류가 발생하지 않고, 사용자 정보가 없는 것으로 처리됩니다.

- **Refactor**
  - 사용자 로그인 상태의 초기값이 항상 false로 설정되도록 변경되었습니다.
  - 만료된 토큰에 대한 에러 로그가 출력되지 않도록 개선되었습니다.

- **Chores**
  - 서버에서 사용자 정보를 항상 최신 상태로 가져오도록 캐시 정책이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->