### PR TITLE
SettingPage에서 사용자 정보를 API 요청 대신 store에 가져오도록 변경

### DIFF
--- a/src/app/my/setting/components/SettingUserImage/index.tsx
+++ b/src/app/my/setting/components/SettingUserImage/index.tsx
@@ -2,18 +2,15 @@
 
 import { updateUser } from '@/api/user';
 import { DEFAULT_PROFILE } from '@/constants';
-import type { User } from '@/types';
+import { useUserStore } from '@/store/user';
 import { Button } from '@mui/material';
 import Image from 'next/image';
 import { ChangeEvent, useState } from 'react';
 import { useRemoveProfileImage, useUploadProfileImage } from '../../hooks';
 import classes from './SettingUserImage.module.scss';
 
-type SettingUserImageProps = {
-  user: User;
-};
-
-export default function SettingUserImage({ user }: SettingUserImageProps) {
+export default function SettingUserImage() {
+  const user = useUserStore.use.user();
   const uploadProfileImage = useUploadProfileImage();
   const removeProfileImage = useRemoveProfileImage();
   const [loading, setLoading] = useState<boolean>(false);

--- a/src/app/my/setting/components/SettingUserInfo/index.tsx
+++ b/src/app/my/setting/components/SettingUserInfo/index.tsx
@@ -1,17 +1,14 @@
 'use client';
 
 import { updateUser } from '@/api/user';
-import type { User } from '@/types';
+import { useUserStore } from '@/store/user';
 import { sanitizeInput } from '@/utils/sanitize';
 import { Button, FormHelperText, TextField } from '@mui/material';
 import { FormEvent, useState } from 'react';
 import classes from './SettingUserInfo.module.scss';
 
-type SettingUserInfoProps = {
-  user: User;
-};
-
-export default function SettingUserInfo({ user }: SettingUserInfoProps) {
+export default function SettingUserInfo() {
+  const user = useUserStore.use.user();
   const [name, setName] = useState<string>(user?.name || '');
   const [error, setError] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);

--- a/src/app/my/setting/page.tsx
+++ b/src/app/my/setting/page.tsx
@@ -1,4 +1,3 @@
-import { getUser } from '@/api/user';
 import { MaxWidthWrapper } from '@/components/atoms';
 import { Divider } from '@mui/material';
 
@@ -16,13 +15,11 @@ export const metadata: Metadata = {
 };
 
 export default async function SettingPage() {
-  const { data: currentUser } = await getUser();
-
   return (
     <main>
       <MaxWidthWrapper className={classes.wrapper}>
-        <SettingUserImage user={currentUser} />
-        <SettingUserInfo user={currentUser} />
+        <SettingUserImage />
+        <SettingUserInfo />
         <Divider />
         <UserActionButtons />
       </MaxWidthWrapper>


### PR DESCRIPTION
## 작업 개요
현재 SettingPage에서는 사용자 정보를 API로 불러오고 있으나 전역 상태에서 이미 사용자 정보를 가지고 있기 때문에 불필요한 요청이 발생하고 있습니다.

## 주요 변경사항
- SettingPage 및 하위 컴포넌트가 store에서 직접 user 정보 조회
- props 전달 제거 및 fetch 제거

## 관련 이슈
Closes #69 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- 설정 페이지의 사용자 정보 및 프로필 이미지 컴포넌트가 내부적으로 사용자 정보를 직접 가져오도록 개선되었습니다. 이제 별도의 사용자 정보 전달 없이도 동일한 기능을 사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->