### PR TITLE
UserProvider를 이동하여 전역에서 사용자 상태 복원 처리

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,21 +1,37 @@
+import { getUser } from '@/api/user';
 import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
 import '../styles/global.scss';
 import { ClientProviders, Header } from './(main)/components';
+import UserProvider from './(main)/components/UserProvider';
 
 export const metadata: Metadata = {
   title: 'Sentence Share',
   description: '책 속의 문장 공유',
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const cookieStore = cookies();
+  const token = cookieStore.get('access_token');
+  let user = null;
+  if (token?.value) {
+    try {
+      const { data } = await getUser();
+      user = data;
+    } catch (error) {
+      console.error('사용자 정보 가져오기 실패:', error);
+    }
+  }
+
   return (
     <html lang="ko-KR">
       <body>
         <div id="root">
+          <UserProvider user={user} />
           <ClientProviders>
             <div style={{ paddingTop: 56 }}>
               <Header />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,12 +2,9 @@ import { MaxWidthWrapper } from '@/components/atoms';
 import { Pagination } from '@/components/molecules';
 import { SentenceLikeCardList } from '@/components/organisms';
 import { getSortByValue, getSortOrderValue } from '@/utils';
-import { cookies } from 'next/headers';
 
-import { getUser } from '@/api/user';
 import { getSentences } from './(main)/api';
 import { SortButtons } from './(main)/components';
-import UserProvider from './(main)/components/UserProvider';
 import classes from './page.module.scss';
 
 type MainPageProps = {
@@ -19,18 +16,6 @@ export default async function MainPage({ searchParams }: MainPageProps) {
   const sortBy = getSortByValue(_searchParams.get('sortBy'));
   const sortOrder = getSortOrderValue(_searchParams.get('sortOrder'));
 
-  const cookieStore = cookies();
-  const token = cookieStore.get('access_token');
-  let user = null;
-  if (token?.value) {
-    try {
-      const { data } = await getUser();
-      user = data;
-    } catch (error) {
-      console.error('사용자 정보 가져오기 실패:', error);
-    }
-  }
-
   const {
     data: { list, totalPages },
   } = await getSentences({
@@ -41,7 +26,6 @@ export default async function MainPage({ searchParams }: MainPageProps) {
 
   return (
     <main>
-      <UserProvider user={user} />
       <MaxWidthWrapper>
         <div className={classes.buttons}>
           <SortButtons />


### PR DESCRIPTION
## 작업 개요
- 기존에는 메인 페이지(page.tsx)에 UserProvider가 위치해 있어서 메인 페이지에서만 사용자 상태가 초기화되고 있었습니다.
- 모든 페이지 진입 시 사용자 인증 상태를 일관되게 유지하기 위해 UserProvider를 layout.tsx로 이동했습니다.

## 주요 변경사항
- UserProvider를 layout.tsx로 이동
- layout.tsx에서 사용자 정보를 fetch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 서버 측에서 사용자 정보를 가져와 전체 레이아웃에 사용자 컨텍스트를 제공합니다.

- **리팩터**
  - 메인 페이지에서 사용자 인증 관련 로직이 제거되어 코드가 간결해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->