### PR TITLE
문장 목록 페이지에 revalidate 적용 및 수정 후 갱신

### DIFF
--- a/src/api/book.ts
+++ b/src/api/book.ts
@@ -16,6 +16,7 @@ export const getBookSentence = async (params: BookSentenceListParams) => {
   const query = queryString.stringify(rest);
   return fetchAPI<PaginationResult<Sentence>>(
     `/books/${bookId}/sentences?${query}`,
+    { next: { revalidate: 300, tags: ['sentence-list'] } },
   );
 };
 

--- a/src/api/sentence.ts
+++ b/src/api/sentence.ts
@@ -7,5 +7,7 @@ type SentenceDetailParams = {
 };
 
 export const getSentence = async ({ sentenceId }: SentenceDetailParams) => {
-  return fetchAPI<Sentence>(`/sentences/${sentenceId}`);
+  return fetchAPI<Sentence>(`/sentences/${sentenceId}`, {
+    next: { revalidate: 300, tags: [`sentence-${sentenceId}`] },
+  });
 };

--- a/src/app/(main)/api/getSentences.ts
+++ b/src/app/(main)/api/getSentences.ts
@@ -6,7 +6,7 @@ const getSentences = async (params: APIRequestParams) => {
   params.limit = params.limit ?? 12;
   const query = queryString.stringify(params);
   return fetchAPI<PaginationResult<Sentence>>(`/sentences?${query}`, {
-    cache: 'no-store',
+    next: { revalidate: 300, tags: ['sentence-list'] },
   });
 };
 

--- a/src/app/api/sentences/[id]/route.ts
+++ b/src/app/api/sentences/[id]/route.ts
@@ -1,7 +1,7 @@
 import { deleteSentence, getSentence, updateSentence } from '@/db/controllers';
 import { handleError } from '@/db/utils';
 import type { ApiResponse, Sentence } from '@/types';
-import { revalidatePath } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 type SentenceIdParams = { params: { id: string } };
@@ -31,6 +31,9 @@ export async function PUT(req: NextRequest, { params }: SentenceIdParams) {
     const { id: sentenceId } = params;
     const { book, content } = await req.json();
     const data = await updateSentence({ sentenceId, book, content });
+    revalidateTag(`sentence-${sentenceId}`);
+    revalidateTag('sentence-list');
+
     return NextResponse.json({
       success: true,
       data,
@@ -45,7 +48,9 @@ export async function DELETE(req: NextRequest, { params }: SentenceIdParams) {
   try {
     const { id: sentenceId } = params;
     const data = await deleteSentence(sentenceId);
-    revalidatePath('/my/sentence');
+
+    revalidateTag(`sentence-${sentenceId}`);
+    revalidateTag('sentence-list');
 
     return NextResponse.json({
       success: true,

--- a/src/app/api/sentences/route.ts
+++ b/src/app/api/sentences/route.ts
@@ -1,5 +1,6 @@
 import { createSentence, getSentences } from '@/db/controllers';
 import { handleError, parseQuery } from '@/db/utils';
+import { revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(req: NextRequest) {
@@ -20,6 +21,7 @@ export async function POST(req: NextRequest) {
   try {
     const { book, content } = await req.json();
     const data = await createSentence(book, content);
+    revalidateTag('sentence-list');
     return NextResponse.json(
       {
         success: true,

--- a/src/app/edit/sentence/components/SentenceEditContainer/api/updateSentence.ts
+++ b/src/app/edit/sentence/components/SentenceEditContainer/api/updateSentence.ts
@@ -2,7 +2,7 @@ import { fetchAPI } from '@/api/fetcher';
 import type { UpdateSentenceParams } from './type';
 
 const updateSentence = async ({ id, content, book }: UpdateSentenceParams) => {
-  return fetchAPI(`/sentence/${id}`, {
+  return fetchAPI(`/sentences/${id}`, {
     method: 'PUT',
     body: JSON.stringify({ content, book }),
   });

--- a/src/app/my/like/api/getUserLikes.ts
+++ b/src/app/my/like/api/getUserLikes.ts
@@ -6,7 +6,7 @@ const SENTENCE_PAGE_LIMIT = 24;
 const getUserLikes = async (page: string) => {
   return fetchAPI<PaginationResult<Sentence>>(
     `/users/me/likes?page=${page}&limit=${SENTENCE_PAGE_LIMIT}`,
-    { cache: 'no-store' },
+    { next: { revalidate: 300, tags: ['sentence-list'] } },
   );
 };
 

--- a/src/app/my/sentence/components/MySentenceCardButtons/index.tsx
+++ b/src/app/my/sentence/components/MySentenceCardButtons/index.tsx
@@ -19,10 +19,12 @@ export default function MySentenceCardButtons({
   const router = useRouter();
   const [showAlert, setShowAlert] = useState<boolean>(false);
 
+  // TODO: hook으로 분리 + useMutation으로 onSuccess, onError 처리
   const handleDeleteSentence = async () => {
     if (showAlert) {
       await deleteSentence(sentenceId);
       setShowAlert(false);
+      router.refresh();
     }
   };
 


### PR DESCRIPTION
## 작업 개요
- 문장 상세 또는 목록 데이터가 자주 변경되지는 않지만, 수정 시에는 즉시 반영되어야 합니다.
- 초기 로딩 시에는 ISR 방식으로 빠르게 정적 HTML을 제공하고, 수정 시에는 서버 캐시를 무효화하여 최신 데이터로 갱신되도록 구성하였습니다.

## 주요 변경사항
- 문장 목록 API 요청시 next: { revalidate: 300 } 설정을 추가해 ISR 적용
- 문장 수정, 삭제 후 revalidateTag로 fetch 캐시를 무효화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 문장 삭제 후 UI가 즉시 갱신되도록 개선되었습니다.
- **기능 개선**
	- 문장, 책, 좋아요 목록 등 여러 API 요청에 대해 캐시 및 재검증(300초 간격) 전략이 적용되어 데이터 신선도가 향상되었습니다.
	- 문장 생성, 수정, 삭제 시 태그 기반 캐시 무효화로 관련 데이터가 더 정확하게 반영됩니다.
	- 문장 수정 API 경로가 일관성 있게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->