### PR TITLE
화면 전환 시 스피너 표시

### DIFF
--- a/src/app/loading.module.scss
+++ b/src/app/loading.module.scss
@@ -1,3 +1,6 @@
-.buttons {
-  height: 62px;
+.wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 50vh;
 }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,13 +1,11 @@
-import { MaxWidthWrapper } from '@/components/atoms';
-import { SentenceListSkeleton } from '@/components/organisms';
+import { MaxWidthWrapper, Spinner } from '@/components/atoms';
 import classes from './loading.module.scss';
 
 export default function MainLoading() {
   return (
     <main>
-      <MaxWidthWrapper>
-        <div className={classes.buttons}></div>
-        <SentenceListSkeleton />
+      <MaxWidthWrapper className={classes.wrapper}>
+        <Spinner />
       </MaxWidthWrapper>
     </main>
   );


### PR DESCRIPTION
## 작업 개요
loading.tsx에서 <SentenceListSkeleton />을 렌더하기 때문에 화면 전환 시에 시각적으로 부자연스러운 문제가 있어서 개선했습니다.

## 변경 사항
- `/app/loading.tsx`에서 <Spinner /> 컴포넌트를 보여주도록 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
  - 버튼 컨테이너의 고정 높이 스타일이 제거되고, 콘텐츠를 화면 중앙에 배치하는 유연한 레이아웃 스타일로 변경되었습니다.

- **신규 기능**
  - 로딩 화면에 스피너가 추가되어, 더 직관적인 로딩 상태를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->