### PR TITLE
LikeButton 컴포넌트의 상태 관리 및 API 요청 로직 분리 

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,6 +2,7 @@ import { ThemeProvider } from '@mui/material';
 import type { Preview } from '@storybook/nextjs-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { initialize as initializeMsw, mswLoader } from 'msw-storybook-addon';
+import { Toaster } from 'react-hot-toast';
 import '../src/styles/global.scss';
 
 import { MUI_THEME } from '../src/lib/mui/theme';
@@ -44,6 +45,7 @@ const preview: Preview = {
           <QueryClientProvider client={client}>
             <ThemeProvider theme={MUI_THEME}>
               <Story />
+              <Toaster />
             </ThemeProvider>
           </QueryClientProvider>
         </>

--- a/src/api/constants.ts
+++ b/src/api/constants.ts
@@ -5,4 +5,6 @@ export const API_ENDPOINTS = {
   BOOK_SENTENCES: (bookId: string) => `/books/${bookId}/sentences`,
   BOOK_SEARCH_KAKAO: '/books/external/kakao/search',
   GET_SENTENCE: (sentenceId: string) => `/sentences/${sentenceId}`,
+  LIKE_SENTENCE: `/likes`,
+  DISLIKE_SENTENCE: (id: string) => `/likes/sentence/${id}`,
 } as const;

--- a/src/app/api/likes/[category]/[target]/route.ts
+++ b/src/app/api/likes/[category]/[target]/route.ts
@@ -12,7 +12,11 @@ export async function DELETE(
     return NextResponse.json(
       {
         success: true,
-        data: null,
+        data: {
+          isLiked: false,
+          target,
+          category,
+        },
         message: '좋아요를 취소했습니다.',
       },
       { status: 200 },

--- a/src/app/api/likes/route.ts
+++ b/src/app/api/likes/route.ts
@@ -7,7 +7,15 @@ export async function POST(req: NextRequest) {
     const { category, target } = await req.json();
     await addLike({ category, target });
     return NextResponse.json(
-      { success: true, data: null, message: '좋아요를 추가했습니다.' },
+      {
+        success: true,
+        data: {
+          isLiked: true,
+          target,
+          category,
+        },
+        message: '좋아요를 추가했습니다.',
+      },
       { status: 200 },
     );
   } catch (error) {

--- a/src/components/molecules/LikeButton/LikeButton.module.scss
+++ b/src/components/molecules/LikeButton/LikeButton.module.scss
@@ -11,3 +11,15 @@
     color: var(--red500);
   }
 }
+
+.srOnly {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/molecules/LikeButton/LikeButton.stories.tsx
+++ b/src/components/molecules/LikeButton/LikeButton.stories.tsx
@@ -1,4 +1,7 @@
+import { MockUser } from '@/mocks/data';
+import { useUserStore } from '@/store/user';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, screen } from 'storybook/test';
 import LikeButton from '.';
 
 const meta = {
@@ -8,16 +11,56 @@ const meta = {
 
 export default meta;
 type Story = StoryObj<typeof meta>;
-export const Unlike: Story = {
+export const Default: Story = {
+  decorators: [
+    (Story) => {
+      const state = useUserStore.getState();
+      useUserStore.setState({ ...state, user: MockUser, isLogin: true });
+      return <Story />;
+    },
+  ],
   args: {
     id: '1',
     isLiked: false,
   },
 };
 
-export const Like: Story = {
+export const Liked: Story = {
+  decorators: [
+    (Story) => {
+      const state = useUserStore.getState();
+      useUserStore.setState({ ...state, user: MockUser, isLogin: true });
+      return <Story />;
+    },
+  ],
   args: {
     id: '1',
     isLiked: true,
+  },
+};
+
+export const NotLoggedIn: Story = {
+  decorators: [
+    (Story) => {
+      const state = useUserStore.getState();
+      useUserStore.setState({ ...state, user: null, isLogin: false });
+      return <Story />;
+    },
+  ],
+  args: {
+    id: '1',
+    isLiked: false,
+  },
+  play: async ({ canvas, step, userEvent }) => {
+    await step(
+      '비로그인 상태에서 버튼을 클릭하면 로그인하라는 안내 메시지가 표시된다.',
+      async () => {
+        const button = canvas.getByRole('button', { name: '좋아요' });
+        await userEvent.click(button);
+        expect(
+          screen.getByText('로그인 후에 이용해주세요.'),
+        ).toBeInTheDocument();
+      },
+    );
   },
 };

--- a/src/components/molecules/LikeButton/api/toggleSentenceLike.ts
+++ b/src/components/molecules/LikeButton/api/toggleSentenceLike.ts
@@ -1,12 +1,21 @@
+import { API_ENDPOINTS } from '@/api/constants';
 import { fetchAPI } from '@/api/fetcher';
+
+export type LikeApiResponse = {
+  isLiked: boolean;
+  target: string;
+  category: string;
+};
 
 const toggleSentenceLike = async (id: string, isLiked: boolean) => {
   if (isLiked) {
     // 좋아요 취소
-    return fetchAPI(`/likes/sentence/${id}`, { method: 'DELETE' });
+    return fetchAPI<LikeApiResponse>(API_ENDPOINTS.DISLIKE_SENTENCE(id), {
+      method: 'DELETE',
+    });
   } else {
     // 좋아요 추가
-    return fetchAPI(`/likes`, {
+    return fetchAPI<LikeApiResponse>(API_ENDPOINTS.LIKE_SENTENCE, {
       method: 'POST',
       body: JSON.stringify({ category: 'sentence', target: id }),
     });

--- a/src/components/molecules/LikeButton/hooks/index.ts
+++ b/src/components/molecules/LikeButton/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useLike } from './useLike';

--- a/src/components/molecules/LikeButton/hooks/useLike.ts
+++ b/src/components/molecules/LikeButton/hooks/useLike.ts
@@ -1,0 +1,62 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { useUserStore } from '@/store/user';
+import { ApiResponse } from '@/types';
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import { toggleSentenceLike } from '../api';
+import { LikeApiResponse } from '../api/toggleSentenceLike';
+
+type UseLikeProps = {
+  id: string;
+  initialLiked: boolean;
+};
+
+export function useLike({ id, initialLiked }: UseLikeProps) {
+  const [isLiked, setIsLiked] = useState(initialLiked);
+  const isLogin = useUserStore((state) => state.isLogin);
+
+  const mutation = useMutation({
+    mutationFn: async (currentLikedState: boolean) => {
+      return await toggleSentenceLike(id, currentLikedState);
+    },
+    onMutate: async (currentLikedState: boolean) => {
+      // API 응답 전 UI 상태 변경
+      const newLikedState = !currentLikedState;
+      setIsLiked(newLikedState);
+      // 롤백을 위해 이전 상태 반환
+      return { previousLikedState: currentLikedState };
+    },
+    onError: (error, variables, context) => {
+      // 이전 상태로 롤백
+      if (context?.previousLikedState !== undefined) {
+        setIsLiked(context.previousLikedState);
+      }
+
+      console.error('Like Toggle Error:', error);
+      toast('문제가 발생했습니다. 잠시 후 다시 시도해주세요.');
+    },
+    onSuccess: (response: ApiResponse<LikeApiResponse>) => {
+      // API 응답으로 최종 상태 업데이트
+      setIsLiked(response.data.isLiked);
+    },
+  });
+
+  const handleLikeToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    // 로그인하지 않은 경우 요청을 보내지 않는다.
+    if (!isLogin) {
+      toast.error('로그인 후에 이용해주세요.');
+      return;
+    }
+
+    mutation.mutate(isLiked);
+  };
+
+  return {
+    isLiked,
+    handleLikeToggle,
+    isLoading: mutation.isPending,
+  };
+}

--- a/src/components/molecules/LikeButton/index.tsx
+++ b/src/components/molecules/LikeButton/index.tsx
@@ -2,13 +2,10 @@
 
 import { Button } from '@mui/material';
 
-import { useState } from 'react';
-import toast from 'react-hot-toast';
 import { FaHeart, FaRegHeart } from 'react-icons/fa6';
 
-import { useUserStore } from '@/store/user';
 import classes from './LikeButton.module.scss';
-import { toggleSentenceLike } from './api';
+import { useLike } from './hooks';
 
 type LikeButtonProps = {
   isLiked: boolean;
@@ -30,37 +27,24 @@ export default function LikeButton({
   size = 'large',
   color = 'secondary',
 }: LikeButtonProps) {
-  const [isLiked, setIsLiked] = useState(initialLiked);
-  const { isLogin } = useUserStore.getState();
-  const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-
-    // 로그인하지 않은 경우 요청을 보내지 않는다.
-    if (!isLogin) {
-      toast('로그인 후에 이용해주세요.');
-      return;
-    }
-
-    try {
-      await toggleSentenceLike(id, isLiked);
-      setIsLiked(!isLiked);
-    } catch (e) {
-      console.log(e);
-      toast('문제가 발생했습니다. 잠시 후 다시 시도 해주세요.');
-    }
-  };
-
+  const { isLiked, isLoading, handleLikeToggle } = useLike({
+    id,
+    initialLiked,
+  });
   return (
     <Button
       className={classes.button}
       size={size}
       color={color}
       fullWidth={true}
-      onClick={handleClick}
+      onClick={handleLikeToggle}
       type="button"
+      disabled={isLoading}
+      aria-pressed={isLiked}
     >
-      <span>좋아요</span>
+      <span className={classes.srOnly}>
+        {isLiked ? '좋아요 취소' : '좋아요'}
+      </span>
       {isLiked ? <FaHeart /> : <FaRegHeart />}
     </Button>
   );


### PR DESCRIPTION
- LikeButton에 있던 상태 관리 및 API 요청 로직을 useLike Hook으로 분리

close #70 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Storybook 환경에서 토스트 알림(react-hot-toast) 지원이 추가되었습니다.
  * LikeButton에 시각적으로 숨기고 스크린 리더에만 보이는 접근성 스타일이 추가되었습니다.
  * LikeButton의 상태 관리를 위한 커스텀 훅(useLike)이 도입되었습니다.

* **버그 수정**
  * 좋아요/취소 API 응답 구조가 개선되어, 좋아요 상태와 대상 정보를 명확하게 제공합니다.

* **리팩터링**
  * LikeButton 컴포넌트가 내부 상태 및 API 호출 로직을 훅으로 분리하여, 코드가 더욱 간결해졌습니다.
  * 하드코딩된 API 엔드포인트를 상수로 대체하여 유지보수성을 높였습니다.

* **테스트**
  * LikeButton 스토리에 로그인/비로그인 상태별 시나리오와 상호작용 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->