### PR TITLE
책 검색 무한 스크롤 수정

### DIFF
--- a/src/app/edit/sentence/components/BookSearch/components/BookSearchResults/index.tsx
+++ b/src/app/edit/sentence/components/BookSearch/components/BookSearchResults/index.tsx
@@ -1,5 +1,5 @@
 import { Book } from '@/types';
-import { useRef } from 'react';
+import { RefObject, useRef } from 'react';
 import { useInfiniteScroll } from '../../hooks';
 import BookSearchList from '../BookSearchList';
 import BookSearchListSkeleton from '../BookSearchListSkeleton';
@@ -9,6 +9,7 @@ type BookSearchResultsProps = {
   isLoading: boolean;
   onBookSelect: (book: Book) => void;
   onFetchNextPage: () => void;
+  scrollContainer?: RefObject<HTMLElement>;
 };
 
 export default function BookSearchResults({
@@ -16,9 +17,12 @@ export default function BookSearchResults({
   isLoading,
   onBookSelect,
   onFetchNextPage,
+  scrollContainer,
 }: BookSearchResultsProps) {
   const listLoaderRef = useRef<HTMLDivElement>(null);
-  useInfiniteScroll(listLoaderRef, onFetchNextPage);
+  useInfiniteScroll(listLoaderRef, onFetchNextPage, {
+    root: scrollContainer?.current,
+  });
 
   if (isLoading && books?.length === 0) {
     return <BookSearchListSkeleton length={5} />;

--- a/src/app/edit/sentence/components/BookSearch/index.tsx
+++ b/src/app/edit/sentence/components/BookSearch/index.tsx
@@ -59,6 +59,7 @@ export default function BookSearch() {
             isLoading={isLoading}
             onBookSelect={onSelectBook}
             onFetchNextPage={fetchNextPage}
+            scrollContainer={listRef}
           />
         </div>
       )}


### PR DESCRIPTION
- Intersection Observer에 root를 전달하지 않아서 기본값으로 설정됨(viewport 기준)
- 책 검색 목록을 감싸는 요소를 root로 설정하여 무한 스크롤이 안 되던 문제 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 도서 검색 결과의 무한 스크롤이 특정 스크롤 컨테이너 내에서 동작하도록 개선되었습니다.  
  * 검색 결과 리스트가 별도의 스크롤 영역을 사용할 때에도 원활한 무한 스크롤이 지원됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->