### PR TITLE
회원가입 오류 수정

### DIFF
--- a/src/db/controllers/auth.controller.ts
+++ b/src/db/controllers/auth.controller.ts
@@ -33,8 +33,9 @@ export const authWithGoogle = async (
         user,
       };
     } else {
-      const { uid, name, provider, profileUrl, email } = verifyUser;
-      if (!uid || !email || !name || !provider) {
+      const { uid, name, profileUrl, email } = verifyUser;
+
+      if (!uid || !email || !name) {
         throw new HttpError(
           'INVALID_USER_DATA',
           400,
@@ -45,7 +46,7 @@ export const authWithGoogle = async (
       const user = await models.User.create({
         uid,
         name,
-        provider,
+        provider: 'google',
         profileUrl,
         email,
       });


### PR DESCRIPTION
- firebase auth에서 반환한 값에  provider가 없어서 회원가입 시 오류 발생하는 문제를 provider 값을 직접 입력하는 것으로 해결
- google 로그인 함수 내부이기 때문에 provider를 고정해도 상관없다고 판단